### PR TITLE
Fix async/await issue in IPReset

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 const IPReset = require('./src');
-const ipr = new IPReset('platform-tools\adb.exe',1000);
-(() => {
-	await ipr.reset();
-	console.log('Your IP Address has been changed!')
+const ipr = new IPReset('platform-tools\\adb.exe', 1000);
+
+(async () => {
+    try {
+        await ipr.reset();
+        console.log('Your IP Address has been changed!');
+    } catch (error) {
+        console.error('Failed to change IP address:', error);
+    }
 })();


### PR DESCRIPTION
The current usage example of the `IPReset` class contains a syntax error and incorrect handling of asynchronous function calls within an immediately invoked function expression (IIFE). This issue aims to:

1. Correct the path to the ADB executable by properly escaping backslashes.
2. Use an `async` function inside the IIFE to enable the use of `await`.
3. Add error handling to manage potential failures during the IP reset process.

### Proposed Changes:
- Modify the file path to escape backslashes correctly.
- Convert the IIFE to an `async` function to allow the use of `await`.
- Wrap the `await ipr.reset()` call in a try-catch block to handle errors.

### Example of Corrected Code:
```javascript
const IPReset = require('./src');
const ipr = new IPReset('platform-tools\\adb.exe', 1000);

(async () => {
    try {
        await ipr.reset();
        console.log('Your IP Address has been changed!');
    } catch (error) {
        console.error('Failed to change IP address:', error);
    }
})();
